### PR TITLE
Add homepage settings for domains

### DIFF
--- a/lib/class-core.php
+++ b/lib/class-core.php
@@ -262,6 +262,16 @@ class Core {
 	}
 
 	/**
+	 * Get the current site's term ID.
+	 *
+	 * @return int|bool Term ID on success, false if the current site is unknown.
+	 */
+	public static function get_current_site_id() {
+		$current_site = self::get_current_site_from_cache();
+		return ! empty( $current_site['term_id'] ) ? $current_site['term_id'] : false;
+	}
+
+	/**
 	 * Redirect to the canonical version of the current url if the site is not
 	 * correct.
 	 */

--- a/lib/class-site.php
+++ b/lib/class-site.php
@@ -51,7 +51,18 @@ class Site extends Taxonomy {
 
 		add_filter( 'term_link', [ $this, 'term_link' ], 10, 3 );
 
+		add_action( 'switchboard_taxonomy_registered', [ $this, 'register_option_overrides' ] );
+
 		parent::setup();
+	}
+
+	/**
+	 * Register the homepage options overrides.
+	 */
+	public function register_option_overrides() {
+		add_filter( 'pre_option_show_on_front', [ $this, 'homepage_options_overrides' ], 10, 2 );
+		add_filter( 'pre_option_page_on_front', [ $this, 'homepage_options_overrides' ], 10, 2 );
+		add_filter( 'pre_option_page_for_posts', [ $this, 'homepage_options_overrides' ], 10, 2 );
 	}
 
 	/**
@@ -378,5 +389,28 @@ class Site extends Taxonomy {
 		}
 
 		return $termlink;
+	}
+
+	/**
+	 * Override homepage options using options in the site terms.
+	 *
+	 * @param bool|mixed $pre_option The value to return instead of the option
+	 *                               value. This differs from `$default`, which
+	 *                               is used as the fallback value in the event
+	 *                               the option doesn't exist elsewhere in
+	 *                               get_option(). Default false (to skip past
+	 *                               the short-circuit).
+	 * @param string     $option     Option name.
+	 * @return bool|mixed
+	 */
+	public function homepage_options_overrides( $pre_option, $option ) {
+		$current_site_id = Core::get_current_site_id();
+		if ( $current_site_id ) {
+			$value = get_term_meta( $current_site_id, $option, true );
+			if ( '' !== $value ) {
+				return $value;
+			}
+		}
+		return $pre_option;
 	}
 }

--- a/lib/class-walker-page-array.php
+++ b/lib/class-walker-page-array.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Walker_Page_Array Class
+ *
+ * @package Switchboard
+ */
+
+namespace Switchboard;
+
+/**
+ * Class used to create a hierarchical array of pages for use in
+ * Fieldmanager_Select fields.
+ *
+ * @see \Walker
+ */
+class Walker_Page_Array extends \Walker {
+
+	/**
+	 * What the class handles.
+	 *
+	 * @var string
+	 *
+	 * @see \Walker::$tree_type
+	 */
+	public $tree_type = 'page';
+
+	/**
+	 * Database fields to use.
+	 *
+	 * @var array
+	 *
+	 * @see \Walker::$db_fields
+	 */
+	public $db_fields = [
+		'parent' => 'post_parent',
+		'id'     => 'ID',
+	];
+
+	/**
+	 * Starts the element output.
+	 *
+	 * @see \Walker::start_el()
+	 *
+	 * @param string  $output Used to append additional content. Passed by reference.
+	 * @param WP_Post $page   Page data object.
+	 * @param int     $depth  Optional. Depth of page in reference to parent pages. Used for padding.
+	 *                        Default 0.
+	 * @param array   $args   Optional. Uses 'selected' argument for selected page to set selected HTML
+	 *                        attribute for option element. Uses 'value_field' argument to fill "value"
+	 *                        attribute. See wp_dropdown_pages(). Default empty array.
+	 * @param int     $id     Optional. ID of the current page. Default 0 (unused).
+	 */
+	public function start_el( &$output, $page, $depth = 0, $args = array(), $id = 0 ) {
+		$pad = str_repeat('&nbsp;', $depth * 3);
+
+		$title = $page->post_title;
+		if ( '' === $title ) {
+			/* translators: %d: ID of a post */
+			$title = sprintf( __( '#%d (no title)', 'switchboard' ), $page->ID );
+		}
+		$output .= sprintf( '"%s":"%s",', $page->ID, $pad . addcslashes( $title, '"' ) );
+	}
+}


### PR DESCRIPTION
This PR adds the ability for domains to change their homepage. It uses Fieldmanager to add options to the new/edit site screens:

<img width="602" alt="screen shot 2018-11-03 at 4 06 36 pm" src="https://user-images.githubusercontent.com/465154/47956886-c47bf280-df82-11e8-9aa8-77508972c5a1.png">

This mimics core's homepage settings, and then overrides those options on a domain-by-domain basis.